### PR TITLE
Cache generated datasets by test size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ linfa-svm = "0.7.1"
 ndarray = "0.15.6"
 rand = "0.8.5"
 rand_distr = "0.4.3"
+once_cell = "1.19.0"
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["html_reports"] }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum TestSize {
     Small,
     Medium,


### PR DESCRIPTION
## Summary
- add lazy caches keyed by `TestSize` for regression, classification, and clustering datasets
- reuse cached arrays when preparing SmartCore and Linfa inputs so each library sees the same data
- derive copy/hash traits for `TestSize` to support the new caches

## Testing
- cargo fmt
- cargo clippy -- -D warnings
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf20f84d3c832596f7e4fb29b65797