### PR TITLE
Implement deterministic dataset generation with seeded RNG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ linfa-svm = "0.7.1"
 ndarray = "0.15.6"
 rand = "0.8.5"
 rand_distr = "0.4.3"
-once_cell = "1.19.0"
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The documentation for `smartcore` is a bit more consistent across algorithms. Th
 ### Dependencies
 While `linfa` requires a BLAS/LAPACK backend (either `openblas`, `netblas`, or `intel-mkl`), `smartcore` does not. This allows `linfa` to take advantage of some additional optimization, but it limits portability.
 
+### Dataset Determinism
+Benchmark datasets are now generated from deterministic random seeds that pair each [`TestSize`](https://docs.rs/smartcore_vs_linfa/latest/smartcore_vs_linfa/enum.TestSize.html) with a scenario (`regression`, `classification`, or `clustering`). This ensures that all cached helpers (`xy_regression`, `xy_classification`, and `x_unsupervised`) draw from reproducible inputs across runs, aligning the smartcore and linfa comparisons.
+
 ## Results
 ### Regression
 #### [Linear Regression](criterion/Linear%20Regression/report/index.html)

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -1,20 +1,21 @@
-use criterion::{
-    black_box, criterion_group, criterion_main, AxisScale, Criterion, PlotConfiguration,
-};
+use criterion::{criterion_group, criterion_main, AxisScale, Criterion, PlotConfiguration};
 use smartcore_vs_linfa::TestSize;
+use std::hint::black_box;
 
 // A benchmark function for linear regression
 fn linear_regression_benchmark(c: &mut Criterion) {
     let mut bm = c.benchmark_group("Linear Regression");
     bm.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-    for test_size in [TestSize::Small, TestSize::Medium, TestSize::Large].iter() {
-        bm.bench_function(format!("{}/Smart", test_size), |b| {
+    for test_size in &[TestSize::Small, TestSize::Medium, TestSize::Large] {
+        bm.bench_function(format!("{test_size}/Smart"), |b| {
             let (x, y) = smartcore_vs_linfa::get_smartcore_regression_data(test_size);
-            b.iter(|| smartcore_vs_linfa::smartcore_linear_regression(black_box(&x), black_box(&y)))
+            b.iter(|| {
+                smartcore_vs_linfa::smartcore_linear_regression(black_box(&x), black_box(&y));
+            });
         });
-        bm.bench_function(format!("{}/Linfa", test_size), |b| {
+        bm.bench_function(format!("{test_size}/Linfa"), |b| {
             let dataset = smartcore_vs_linfa::get_linfa_regression_data(test_size);
-            b.iter(|| smartcore_vs_linfa::linfa_linear_regression(black_box(&dataset)))
+            b.iter(|| smartcore_vs_linfa::linfa_linear_regression(black_box(&dataset)));
         });
     }
 }
@@ -23,16 +24,16 @@ fn linear_regression_benchmark(c: &mut Criterion) {
 fn elasticnet_regression_benchmark(c: &mut Criterion) {
     let mut bm = c.benchmark_group("Elastic Net");
     bm.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-    for test_size in [TestSize::Small, TestSize::Medium, TestSize::Large].iter() {
-        bm.bench_function(format!("{}/Smart", test_size), |b| {
+    for test_size in &[TestSize::Small, TestSize::Medium, TestSize::Large] {
+        bm.bench_function(format!("{test_size}/Smart"), |b| {
             let (x, y) = smartcore_vs_linfa::get_smartcore_regression_data(test_size);
             b.iter(|| {
-                smartcore_vs_linfa::smartcore_elasticnet_regression(black_box(&x), black_box(&y))
-            })
+                smartcore_vs_linfa::smartcore_elasticnet_regression(black_box(&x), black_box(&y));
+            });
         });
-        bm.bench_function(format!("{}/Linfa", test_size), |b| {
+        bm.bench_function(format!("{test_size}/Linfa"), |b| {
             let dataset = smartcore_vs_linfa::get_linfa_regression_data(test_size);
-            b.iter(|| smartcore_vs_linfa::linfa_elasticnet_regression(black_box(&dataset)))
+            b.iter(|| smartcore_vs_linfa::linfa_elasticnet_regression(black_box(&dataset)));
         });
     }
 }
@@ -41,14 +42,14 @@ fn elasticnet_regression_benchmark(c: &mut Criterion) {
 fn svr_benchmark(c: &mut Criterion) {
     let mut bm = c.benchmark_group("Support Vector Regression");
     bm.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-    for test_size in [TestSize::Small, TestSize::Medium].iter() {
-        bm.bench_function(format!("{}/Smart", test_size), |b| {
+    for test_size in &[TestSize::Small, TestSize::Medium] {
+        bm.bench_function(format!("{test_size}/Smart"), |b| {
             let (x, y) = smartcore_vs_linfa::get_smartcore_regression_data(test_size);
-            b.iter(|| smartcore_vs_linfa::smartcore_svm_regression(black_box(&x), black_box(&y)))
+            b.iter(|| smartcore_vs_linfa::smartcore_svm_regression(black_box(&x), black_box(&y)));
         });
-        bm.bench_function(format!("{}/Linfa", test_size), |b| {
+        bm.bench_function(format!("{test_size}/Linfa"), |b| {
             let dataset = smartcore_vs_linfa::get_linfa_regression_data(test_size);
-            b.iter(|| smartcore_vs_linfa::linfa_svm_regression(black_box(&dataset)))
+            b.iter(|| smartcore_vs_linfa::linfa_svm_regression(black_box(&dataset)));
         });
     }
 }
@@ -57,16 +58,16 @@ fn svr_benchmark(c: &mut Criterion) {
 fn logistic_regression_benchmark(c: &mut Criterion) {
     let mut bm = c.benchmark_group("Logistic Regression");
     bm.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-    for test_size in [TestSize::Small, TestSize::Medium, TestSize::Large].iter() {
-        bm.bench_function(format!("{}/Smart", test_size), |b| {
+    for test_size in &[TestSize::Small, TestSize::Medium, TestSize::Large] {
+        bm.bench_function(format!("{test_size}/Smart"), |b| {
             let (x, y) = smartcore_vs_linfa::get_smartcore_classification_data(test_size);
             b.iter(|| {
-                smartcore_vs_linfa::smartcore_logistic_regression(black_box(&x), black_box(&y))
-            })
+                smartcore_vs_linfa::smartcore_logistic_regression(black_box(&x), black_box(&y));
+            });
         });
-        bm.bench_function(format!("{}/Linfa", test_size), |b| {
+        bm.bench_function(format!("{test_size}/Linfa"), |b| {
             let dataset = smartcore_vs_linfa::get_linfa_classification_data(test_size);
-            b.iter(|| smartcore_vs_linfa::linfa_logistic_regression(black_box(&dataset)))
+            b.iter(|| smartcore_vs_linfa::linfa_logistic_regression(black_box(&dataset)));
         });
     }
 }
@@ -75,16 +76,19 @@ fn logistic_regression_benchmark(c: &mut Criterion) {
 fn decision_tree_classifier_benchmark(c: &mut Criterion) {
     let mut bm = c.benchmark_group("Decision Tree Classification");
     bm.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-    for test_size in [TestSize::Small, TestSize::Medium, TestSize::Large].iter() {
-        bm.bench_function(format!("{}/Smart", test_size), |b| {
+    for test_size in &[TestSize::Small, TestSize::Medium, TestSize::Large] {
+        bm.bench_function(format!("{test_size}/Smart"), |b| {
             let (x, y) = smartcore_vs_linfa::get_smartcore_classification_data(test_size);
             b.iter(|| {
-                smartcore_vs_linfa::smartcore_decision_tree_classifier(black_box(&x), black_box(&y))
-            })
+                smartcore_vs_linfa::smartcore_decision_tree_classifier(
+                    black_box(&x),
+                    black_box(&y),
+                );
+            });
         });
-        bm.bench_function(format!("{}/Linfa", test_size), |b| {
+        bm.bench_function(format!("{test_size}/Linfa"), |b| {
             let dataset = smartcore_vs_linfa::get_linfa_classification_data(test_size);
-            b.iter(|| smartcore_vs_linfa::linfa_decision_tree_classifier(black_box(&dataset)))
+            b.iter(|| smartcore_vs_linfa::linfa_decision_tree_classifier(black_box(&dataset)));
         });
     }
 }
@@ -93,14 +97,14 @@ fn decision_tree_classifier_benchmark(c: &mut Criterion) {
 fn gnb_benchmark(c: &mut Criterion) {
     let mut bm = c.benchmark_group("Gaussian Naive Bayes");
     bm.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-    for test_size in [TestSize::Small, TestSize::Medium, TestSize::Large].iter() {
-        bm.bench_function(format!("{}/Smart", test_size), |b| {
+    for test_size in &[TestSize::Small, TestSize::Medium, TestSize::Large] {
+        bm.bench_function(format!("{test_size}/Smart"), |b| {
             let (x, y) = smartcore_vs_linfa::get_smartcore_classification_data(test_size);
-            b.iter(|| smartcore_vs_linfa::smartcore_gnb_classifier(black_box(&x), black_box(&y)))
+            b.iter(|| smartcore_vs_linfa::smartcore_gnb_classifier(black_box(&x), black_box(&y)));
         });
-        bm.bench_function(format!("{}/Linfa", test_size), |b| {
+        bm.bench_function(format!("{test_size}/Linfa"), |b| {
             let dataset = smartcore_vs_linfa::get_linfa_classification_data(test_size);
-            b.iter(|| smartcore_vs_linfa::linfa_gnb_classifier(black_box(&dataset)))
+            b.iter(|| smartcore_vs_linfa::linfa_gnb_classifier(black_box(&dataset)));
         });
     }
 }
@@ -109,14 +113,14 @@ fn gnb_benchmark(c: &mut Criterion) {
 fn svc_benchmark(c: &mut Criterion) {
     let mut bm = c.benchmark_group("Support Vector Classification");
     bm.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-    for test_size in [TestSize::Small, TestSize::Medium].iter() {
-        bm.bench_function(format!("{}/Smart", test_size), |b| {
+    for test_size in &[TestSize::Small, TestSize::Medium] {
+        bm.bench_function(format!("{test_size}/Smart"), |b| {
             let (x, y) = smartcore_vs_linfa::get_smartcore_classification_data(test_size);
-            b.iter(|| smartcore_vs_linfa::smartcore_svm_classifier(black_box(&x), black_box(&y)))
+            b.iter(|| smartcore_vs_linfa::smartcore_svm_classifier(black_box(&x), black_box(&y)));
         });
-        bm.bench_function(format!("{}/Linfa", test_size), |b| {
+        bm.bench_function(format!("{test_size}/Linfa"), |b| {
             let dataset = smartcore_vs_linfa::get_linfa_classification_data_as_bool(test_size);
-            b.iter(|| smartcore_vs_linfa::linfa_svm_classifier(black_box(&dataset)))
+            b.iter(|| smartcore_vs_linfa::linfa_svm_classifier(black_box(&dataset)));
         });
     }
 }
@@ -125,14 +129,14 @@ fn svc_benchmark(c: &mut Criterion) {
 fn kmeans_clustering_benchmark(c: &mut Criterion) {
     let mut bm = c.benchmark_group("K-Means Clustering");
     bm.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-    for test_size in [TestSize::Small, TestSize::Medium, TestSize::Large].iter() {
-        bm.bench_function(format!("{}/Smart", test_size), |b| {
+    for test_size in &[TestSize::Small, TestSize::Medium, TestSize::Large] {
+        bm.bench_function(format!("{test_size}/Smart"), |b| {
             let x = smartcore_vs_linfa::get_smartcore_unsupervised_data(test_size);
-            b.iter(|| smartcore_vs_linfa::smartcore_kmeans(black_box(&x)))
+            b.iter(|| smartcore_vs_linfa::smartcore_kmeans(black_box(&x)));
         });
-        bm.bench_function(format!("{}/Linfa", test_size), |b| {
+        bm.bench_function(format!("{test_size}/Linfa"), |b| {
             let dataset = smartcore_vs_linfa::get_linfa_unsupervised_data(test_size);
-            b.iter(|| smartcore_vs_linfa::linfa_kmeans(black_box(&dataset)))
+            b.iter(|| smartcore_vs_linfa::linfa_kmeans(black_box(&dataset)));
         });
     }
 }
@@ -141,14 +145,14 @@ fn kmeans_clustering_benchmark(c: &mut Criterion) {
 fn dbscan_clustering_benchmark(c: &mut Criterion) {
     let mut bm = c.benchmark_group("DBSCAN Clustering");
     bm.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-    for test_size in [TestSize::Small, TestSize::Medium, TestSize::Large].iter() {
-        bm.bench_function(format!("{}/Smart", test_size), |b| {
+    for test_size in &[TestSize::Small, TestSize::Medium, TestSize::Large] {
+        bm.bench_function(format!("{test_size}/Smart"), |b| {
             let x = smartcore_vs_linfa::get_smartcore_unsupervised_data(test_size);
-            b.iter(|| smartcore_vs_linfa::smartcore_dbscan(black_box(&x)))
+            b.iter(|| smartcore_vs_linfa::smartcore_dbscan(black_box(&x)));
         });
-        bm.bench_function(format!("{}/Linfa", test_size), |b| {
+        bm.bench_function(format!("{test_size}/Linfa"), |b| {
             let dataset = smartcore_vs_linfa::x_unsupervised(test_size);
-            b.iter(|| smartcore_vs_linfa::linfa_dbscan(black_box(&dataset)))
+            b.iter(|| smartcore_vs_linfa::linfa_dbscan(black_box(&dataset)));
         });
     }
 }
@@ -157,14 +161,14 @@ fn dbscan_clustering_benchmark(c: &mut Criterion) {
 fn pca_benchmark(c: &mut Criterion) {
     let mut bm = c.benchmark_group("PCA");
     bm.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-    for test_size in [TestSize::Small, TestSize::Medium, TestSize::Large].iter() {
-        bm.bench_function(format!("{}/Smart", test_size), |b| {
+    for test_size in &[TestSize::Small, TestSize::Medium, TestSize::Large] {
+        bm.bench_function(format!("{test_size}/Smart"), |b| {
             let x = smartcore_vs_linfa::get_smartcore_unsupervised_data(test_size);
-            b.iter(|| smartcore_vs_linfa::smartcore_pca(black_box(&x)))
+            b.iter(|| smartcore_vs_linfa::smartcore_pca(black_box(&x)));
         });
-        bm.bench_function(format!("{}/Linfa", test_size), |b| {
+        bm.bench_function(format!("{test_size}/Linfa"), |b| {
             let dataset = smartcore_vs_linfa::get_linfa_unsupervised_data(test_size);
-            b.iter(|| smartcore_vs_linfa::linfa_pca(black_box(&dataset)))
+            b.iter(|| smartcore_vs_linfa::linfa_pca(black_box(&dataset)));
         });
     }
 }

--- a/src/classification.rs
+++ b/src/classification.rs
@@ -4,11 +4,15 @@ use linfa_logistic::LogisticRegression as LinfaLogisticRegression;
 use linfa_svm::Svm as LinfaSvm;
 use linfa_trees::{DecisionTree as LinfaDecisionTree, SplitQuality};
 use ndarray::{Array1, Array2, Ix1};
-use once_cell::sync::Lazy;
+use rand::distributions::Uniform;
+use rand::rngs::StdRng;
+use rand_distr::{Distribution, Normal};
 use smartcore::{
-    dataset::{generator::make_blobs, Dataset as SCDataset},
+    dataset::Dataset as SCDataset,
     linalg::basic::matrix::DenseMatrix,
-    linear::logistic_regression::LogisticRegression as SCLogisticRegression,
+    linear::logistic_regression::{
+        LogisticRegression as SCLogisticRegression, LogisticRegressionParameters,
+    },
     naive_bayes::gaussian::{GaussianNB as SCGaussianNB, GaussianNBParameters},
     svm::{
         svc::{SVCParameters, SVC as SCSVC},
@@ -18,67 +22,136 @@ use smartcore::{
         DecisionTreeClassifier, DecisionTreeClassifierParameters, SplitCriterion,
     },
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::LazyLock};
 
-use super::TestSize;
+use super::{seeded_rng, TestSize};
 use crate::array2_to_dense_matrix;
 
+/// Convert a `SmartCore` classification dataset into dense ndarray arrays.
+///
+/// # Panics
+///
+/// Panics if the underlying data vector cannot be reshaped into a
+/// `num_samples` by `num_features` matrix. This should only occur when the
+/// dataset metadata is inconsistent.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#[must_use]
 pub fn dataset_to_classification_array(
-    dataset: SCDataset<f32, f32>,
+    dataset: &SCDataset<f32, f32>,
 ) -> (Array2<f64>, Array1<usize>) {
     (
         Array2::from_shape_vec(
             (dataset.num_samples, dataset.num_features),
-            dataset.data.iter().map(|elem| *elem as f64).collect(),
+            dataset.data.iter().map(|elem| f64::from(*elem)).collect(),
         )
-        .unwrap()
-        .to_owned(),
-        Array1::from_vec(dataset.target.iter().map(|elem| *elem as usize).collect()).to_owned(),
+        .unwrap(),
+        Array1::from_vec(dataset.target.iter().map(|elem| *elem as usize).collect()),
     )
 }
 
 type ClassificationData = (Array2<f64>, Array1<usize>);
 type ClassificationCache = HashMap<TestSize, ClassificationData>;
 
-static CLASSIFICATION_DATA_CACHE: Lazy<ClassificationCache> = Lazy::new(|| {
+static CLASSIFICATION_DATA_CACHE: LazyLock<ClassificationCache> = LazyLock::new(|| {
     HashMap::from([
-        (
-            TestSize::Small,
-            dataset_to_classification_array(make_blobs(100, 10, 2)),
-        ),
+        (TestSize::Small, build_classification_data(TestSize::Small)),
         (
             TestSize::Medium,
-            dataset_to_classification_array(make_blobs(1000, 50, 2)),
+            build_classification_data(TestSize::Medium),
         ),
-        (
-            TestSize::Large,
-            dataset_to_classification_array(make_blobs(10000, 100, 2)),
-        ),
+        (TestSize::Large, build_classification_data(TestSize::Large)),
     ])
 });
 
-fn classification_cache(size: &TestSize) -> &'static ClassificationData {
+#[allow(clippy::cast_precision_loss)]
+fn make_seeded_blobs(
+    rng: &mut StdRng,
+    num_samples: usize,
+    num_features: usize,
+    num_centers: usize,
+) -> SCDataset<f32, f32> {
+    let center_box = Uniform::from(-10.0..10.0);
+    let cluster_std = 1.0;
+    let mut centers: Vec<Vec<Normal<f32>>> = Vec::with_capacity(num_centers);
+
+    for _ in 0..num_centers {
+        centers.push(
+            (0..num_features)
+                .map(|_| Normal::new(center_box.sample(rng), cluster_std).unwrap())
+                .collect(),
+        );
+    }
+
+    let mut y: Vec<f32> = Vec::with_capacity(num_samples);
+    let mut x: Vec<f32> = Vec::with_capacity(num_samples * num_features);
+
+    for sample_index in 0..num_samples {
+        let label = sample_index % num_centers;
+        y.push(label as f32);
+        for feature_index in 0..num_features {
+            x.push(centers[label][feature_index].sample(rng));
+        }
+    }
+
+    SCDataset {
+        data: x,
+        target: y,
+        num_samples,
+        num_features,
+        feature_names: (0..num_features).map(|n| n.to_string()).collect(),
+        target_names: vec!["label".to_string()],
+        description: "Isotropic Gaussian blobs".to_string(),
+    }
+}
+
+fn build_classification_data(size: TestSize) -> ClassificationData {
+    let (num_samples, num_features, num_centers) = match size {
+        TestSize::Small => (100, 10, 2),
+        TestSize::Medium => (1000, 50, 2),
+        TestSize::Large => (10000, 100, 2),
+    };
+
+    let mut rng = seeded_rng(size, "classification");
+    let dataset = make_seeded_blobs(&mut rng, num_samples, num_features, num_centers);
+    dataset_to_classification_array(&dataset)
+}
+
+fn classification_cache(size: TestSize) -> &'static ClassificationData {
     CLASSIFICATION_DATA_CACHE
-        .get(size)
+        .get(&size)
         .expect("classification data cache is populated for all test sizes")
 }
 
+#[must_use]
 pub fn xy_classification(size: &TestSize) -> (Array2<f64>, Array1<usize>) {
-    let (x, y) = classification_cache(size);
+    let (x, y) = classification_cache(*size);
     (x.clone(), y.clone())
 }
 
+/// Retrieve `SmartCore`-compatible classification inputs.
+///
+/// # Panics
+///
+/// Panics if the cached ndarray cannot be converted into a dense matrix or if
+/// a class label exceeds the bounds of `u32`.
+#[must_use]
 pub fn get_smartcore_classification_data(size: &TestSize) -> (DenseMatrix<f64>, Vec<u32>) {
     let (x, y) = xy_classification(size);
     let dense = array2_to_dense_matrix(&x).expect("valid dense matrix conversion");
-    (dense, y.iter().map(|&elem| elem as u32).collect())
+    let classes: Vec<u32> = y
+        .iter()
+        .map(|&elem| u32::try_from(elem).expect("class label fits into u32"))
+        .collect();
+    (dense, classes)
 }
 
+#[must_use]
 pub fn get_linfa_classification_data(size: &TestSize) -> Dataset<f64, usize, Ix1> {
     let (x, y) = xy_classification(size);
     Dataset::new(x, y)
 }
 
+#[must_use]
 pub fn get_linfa_classification_data_as_bool(size: &TestSize) -> Dataset<f64, bool, Ix1> {
     let (x, y) = xy_classification(size);
     let ybool = y.mapv(|elem| elem == 1);
@@ -86,16 +159,24 @@ pub fn get_linfa_classification_data_as_bool(size: &TestSize) -> Dataset<f64, bo
 }
 
 /// Logistic regression smartcore
+///
+/// # Panics
+///
+/// Panics if the `SmartCore` optimizer fails to converge.
 /// ```
 /// use smartcore_vs_linfa::{get_smartcore_classification_data, smartcore_logistic_regression, TestSize};
 /// let (x, y) = get_smartcore_classification_data(&TestSize::Small);
 /// smartcore_logistic_regression(&x, &y);
 /// ```
 pub fn smartcore_logistic_regression(x: &DenseMatrix<f64>, y: &Vec<u32>) {
-    SCLogisticRegression::fit(x, y, Default::default()).unwrap();
+    SCLogisticRegression::fit(x, y, LogisticRegressionParameters::default()).unwrap();
 }
 
 /// linfa logistic regression
+///
+/// # Panics
+///
+/// Panics if the Linfa optimizer fails to converge.
 /// ```
 /// use smartcore_vs_linfa::{get_linfa_classification_data, linfa_logistic_regression, TestSize};
 /// linfa_logistic_regression(&get_linfa_classification_data(&TestSize::Small));
@@ -109,6 +190,10 @@ pub fn linfa_logistic_regression(dataset: &Dataset<f64, usize, Ix1>) {
 }
 
 /// Decision tree smartcore
+///
+/// # Panics
+///
+/// Panics if the tree learner encounters invalid parameters.
 /// ```
 /// use smartcore_vs_linfa::{get_smartcore_classification_data, smartcore_decision_tree_classifier, TestSize};
 /// let (x, y) = get_smartcore_classification_data(&TestSize::Small);
@@ -124,6 +209,10 @@ pub fn smartcore_decision_tree_classifier(x: &DenseMatrix<f64>, y: &Vec<u32>) {
 }
 
 /// decision tree linfa
+///
+/// # Panics
+///
+/// Panics if the Linfa decision tree training fails.
 /// ```
 /// use smartcore_vs_linfa::{get_linfa_classification_data, linfa_decision_tree_classifier, TestSize};
 /// linfa_decision_tree_classifier(&get_linfa_classification_data(&TestSize::Small));
@@ -139,6 +228,10 @@ pub fn linfa_decision_tree_classifier(dataset: &Dataset<f64, usize, Ix1>) {
 }
 
 /// gaussian naive bayes smartcore
+///
+/// # Panics
+///
+/// Panics if Gaussian Naive Bayes training fails in `SmartCore`.
 /// ```
 /// use smartcore_vs_linfa::{get_smartcore_classification_data, smartcore_gnb_classifier, TestSize};
 /// let (x, y) = get_smartcore_classification_data(&TestSize::Small);
@@ -149,6 +242,10 @@ pub fn smartcore_gnb_classifier(x: &DenseMatrix<f64>, y: &Vec<u32>) {
 }
 
 /// gaussian naive bayes linfa
+///
+/// # Panics
+///
+/// Panics if Gaussian Naive Bayes training fails in Linfa.
 /// ```
 /// use smartcore_vs_linfa::{get_linfa_classification_data, linfa_gnb_classifier, TestSize};
 /// linfa_gnb_classifier(&get_linfa_classification_data(&TestSize::Small));
@@ -158,6 +255,10 @@ pub fn linfa_gnb_classifier(dataset: &Dataset<f64, usize, Ix1>) {
 }
 
 /// svm smartcore
+///
+/// # Panics
+///
+/// Panics if the `SmartCore` SVM optimizer fails to converge.
 /// ```
 /// use smartcore_vs_linfa::{get_smartcore_classification_data, smartcore_svm_classifier, TestSize};
 /// let (x, y) = get_smartcore_classification_data(&TestSize::Small);
@@ -169,10 +270,36 @@ pub fn smartcore_svm_classifier(x: &DenseMatrix<f64>, y: &Vec<u32>) {
 }
 
 /// svm linfa
+///
+/// # Panics
+///
+/// Panics if the Linfa SVM optimizer fails to converge.
 /// ```
 /// use smartcore_vs_linfa::{get_linfa_classification_data_as_bool, linfa_svm_classifier, TestSize};
 /// linfa_svm_classifier(&get_linfa_classification_data_as_bool(&TestSize::Small));
 /// ```
 pub fn linfa_svm_classifier(dataset: &Dataset<f64, bool, Ix1>) {
     LinfaSvm::<_, bool>::params().fit(dataset).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classification_data_is_deterministic() {
+        let (x_a, y_a) = super::build_classification_data(TestSize::Small);
+        let (x_b, y_b) = super::build_classification_data(TestSize::Small);
+
+        assert_eq!(x_a, x_b);
+        assert_eq!(y_a, y_b);
+    }
+
+    #[test]
+    fn classification_data_changes_with_size() {
+        let (small_x, _) = super::build_classification_data(TestSize::Small);
+        let (medium_x, _) = super::build_classification_data(TestSize::Medium);
+
+        assert_ne!(small_x, medium_x);
+    }
 }

--- a/src/clustering.rs
+++ b/src/clustering.rs
@@ -1,69 +1,133 @@
 use linfa::prelude::*;
 use linfa_clustering::{Dbscan as LinfaDbscan, KMeans as LinfaKMeans};
 use ndarray::{Array2, Ix1};
-use once_cell::sync::Lazy;
+use rand::distributions::Uniform;
+use rand::rngs::StdRng;
+use rand_distr::{Distribution, Normal};
 use smartcore::{
     cluster::{
         dbscan::{DBSCANParameters, DBSCAN as SCDBSCAN},
         kmeans::{KMeans as SCKMeans, KMeansParameters},
     },
-    dataset::{generator::make_blobs, Dataset as SCDataset},
+    dataset::Dataset as SCDataset,
     linalg::basic::matrix::DenseMatrix,
     metrics::distance::euclidian::Euclidian,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::LazyLock};
 
-use super::TestSize;
+use super::{seeded_rng, TestSize};
 use crate::array2_to_dense_matrix;
 
-pub fn dataset_to_unsupervised_array(dataset: SCDataset<f32, f32>) -> Array2<f64> {
+/// Convert a `SmartCore` unsupervised dataset into a dense ndarray matrix.
+///
+/// # Panics
+///
+/// Panics if the dataset metadata does not align with the length of the
+/// flattened feature vector.
+#[must_use]
+pub fn dataset_to_unsupervised_array(dataset: &SCDataset<f32, f32>) -> Array2<f64> {
     Array2::from_shape_vec(
         (dataset.num_samples, dataset.num_features),
-        dataset.data.iter().map(|elem| *elem as f64).collect(),
+        dataset.data.iter().map(|elem| f64::from(*elem)).collect(),
     )
     .unwrap()
-    .to_owned()
 }
 
 type UnsupervisedCache = HashMap<TestSize, Array2<f64>>;
 
-static UNSUPERVISED_DATA_CACHE: Lazy<UnsupervisedCache> = Lazy::new(|| {
+static UNSUPERVISED_DATA_CACHE: LazyLock<UnsupervisedCache> = LazyLock::new(|| {
     HashMap::from([
-        (
-            TestSize::Small,
-            dataset_to_unsupervised_array(make_blobs(100, 10, 5)),
-        ),
-        (
-            TestSize::Medium,
-            dataset_to_unsupervised_array(make_blobs(1000, 50, 10)),
-        ),
-        (
-            TestSize::Large,
-            dataset_to_unsupervised_array(make_blobs(10000, 100, 20)),
-        ),
+        (TestSize::Small, build_unsupervised_data(TestSize::Small)),
+        (TestSize::Medium, build_unsupervised_data(TestSize::Medium)),
+        (TestSize::Large, build_unsupervised_data(TestSize::Large)),
     ])
 });
 
-fn unsupervised_cache(size: &TestSize) -> &'static Array2<f64> {
+#[allow(clippy::cast_precision_loss)]
+fn make_seeded_blobs(
+    rng: &mut StdRng,
+    num_samples: usize,
+    num_features: usize,
+    num_centers: usize,
+) -> SCDataset<f32, f32> {
+    let center_box = Uniform::from(-10.0..10.0);
+    let cluster_std = 1.0;
+    let mut centers: Vec<Vec<Normal<f32>>> = Vec::with_capacity(num_centers);
+
+    for _ in 0..num_centers {
+        centers.push(
+            (0..num_features)
+                .map(|_| Normal::new(center_box.sample(rng), cluster_std).unwrap())
+                .collect(),
+        );
+    }
+
+    let mut y: Vec<f32> = Vec::with_capacity(num_samples);
+    let mut x: Vec<f32> = Vec::with_capacity(num_samples * num_features);
+
+    for sample_index in 0..num_samples {
+        let label = sample_index % num_centers;
+        y.push(label as f32);
+        for feature_index in 0..num_features {
+            x.push(centers[label][feature_index].sample(rng));
+        }
+    }
+
+    SCDataset {
+        data: x,
+        target: y,
+        num_samples,
+        num_features,
+        feature_names: (0..num_features).map(|n| n.to_string()).collect(),
+        target_names: vec!["label".to_string()],
+        description: "Isotropic Gaussian blobs".to_string(),
+    }
+}
+
+fn build_unsupervised_data(size: TestSize) -> Array2<f64> {
+    let (num_samples, num_features, num_centers) = match size {
+        TestSize::Small => (100, 10, 5),
+        TestSize::Medium => (1000, 50, 10),
+        TestSize::Large => (10000, 100, 20),
+    };
+
+    let mut rng = seeded_rng(size, "clustering");
+    let dataset = make_seeded_blobs(&mut rng, num_samples, num_features, num_centers);
+    dataset_to_unsupervised_array(&dataset)
+}
+
+fn unsupervised_cache(size: TestSize) -> &'static Array2<f64> {
     UNSUPERVISED_DATA_CACHE
-        .get(size)
+        .get(&size)
         .expect("unsupervised data cache is populated for all test sizes")
 }
 
+#[must_use]
 pub fn x_unsupervised(size: &TestSize) -> Array2<f64> {
-    unsupervised_cache(size).clone()
+    unsupervised_cache(*size).clone()
 }
 
+/// Retrieve `SmartCore`-compatible unsupervised inputs.
+///
+/// # Panics
+///
+/// Panics if the cached ndarray cannot be converted into a dense matrix.
+#[must_use]
 pub fn get_smartcore_unsupervised_data(size: &TestSize) -> DenseMatrix<f64> {
     let x = x_unsupervised(size);
     array2_to_dense_matrix(&x).expect("valid dense matrix conversion")
 }
 
+#[must_use]
 pub fn get_linfa_unsupervised_data(size: &TestSize) -> Dataset<f64, (), Ix1> {
     Dataset::from(x_unsupervised(size))
 }
 
 /// Run linfa kmeans
+///
+/// # Panics
+///
+/// Panics if the Linfa K-Means solver fails to converge.
 /// ```
 /// use smartcore_vs_linfa::{get_linfa_unsupervised_data, linfa_kmeans, TestSize};
 /// linfa_kmeans(&get_linfa_unsupervised_data(&TestSize::Small));
@@ -77,6 +141,10 @@ pub fn linfa_kmeans(dataset: &Dataset<f64, (), Ix1>) {
 }
 
 /// Run smartcore kmeans
+///
+/// # Panics
+///
+/// Panics if the `SmartCore` K-Means solver fails to converge.
 /// ```
 /// use smartcore_vs_linfa::{get_smartcore_unsupervised_data, smartcore_kmeans, TestSize};
 /// smartcore_kmeans(&get_smartcore_unsupervised_data(&TestSize::Small));
@@ -87,6 +155,10 @@ pub fn smartcore_kmeans(x: &DenseMatrix<f64>) {
 }
 
 /// Run linfa DBSCAN
+///
+/// # Panics
+///
+/// Panics if Linfa DBSCAN fails to process the dataset.
 /// ```
 /// use smartcore_vs_linfa::{linfa_dbscan, TestSize, x_unsupervised};
 /// linfa_dbscan(&x_unsupervised(&TestSize::Small));
@@ -96,6 +168,10 @@ pub fn linfa_dbscan(dataset: &Array2<f64>) {
 }
 
 /// Run smartcore dbscan
+///
+/// # Panics
+///
+/// Panics if `SmartCore` DBSCAN fails to process the dataset.
 /// ```
 /// use smartcore_vs_linfa::{get_smartcore_unsupervised_data, smartcore_dbscan, TestSize};
 /// smartcore_dbscan(&get_smartcore_unsupervised_data(&TestSize::Small));
@@ -105,4 +181,25 @@ pub fn smartcore_dbscan(x: &DenseMatrix<f64>) {
         .with_min_samples(5)
         .with_eps(1e-4);
     SCDBSCAN::<f64, i32, DenseMatrix<f64>, Vec<i32>, Euclidian<f64>>::fit(x, params).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupervised_data_is_deterministic() {
+        let data_a = super::build_unsupervised_data(TestSize::Small);
+        let data_b = super::build_unsupervised_data(TestSize::Small);
+
+        assert_eq!(data_a, data_b);
+    }
+
+    #[test]
+    fn unsupervised_data_changes_with_size() {
+        let small = super::build_unsupervised_data(TestSize::Small);
+        let medium = super::build_unsupervised_data(TestSize::Medium);
+
+        assert_ne!(small, medium);
+    }
 }

--- a/src/dimensionality_reduction.rs
+++ b/src/dimensionality_reduction.rs
@@ -7,6 +7,10 @@ use smartcore::{
 };
 
 /// Run linfa pca
+///
+/// # Panics
+///
+/// Panics if Linfa PCA fails to converge for the supplied dataset.
 /// ```
 /// use smartcore_vs_linfa::{get_linfa_unsupervised_data, linfa_pca, TestSize};
 /// linfa_pca(&get_linfa_unsupervised_data(&TestSize::Small));
@@ -16,6 +20,10 @@ pub fn linfa_pca(dataset: &Dataset<f64, (), Ix1>) {
 }
 
 /// Run smartcore pca
+///
+/// # Panics
+///
+/// Panics if `SmartCore` PCA fails to converge for the supplied dataset.
 /// ```
 /// use smartcore_vs_linfa::{get_smartcore_unsupervised_data, smartcore_pca, TestSize};
 /// smartcore_pca(&get_smartcore_unsupervised_data(&TestSize::Small));

--- a/src/regression.rs
+++ b/src/regression.rs
@@ -4,90 +4,112 @@ use linfa_linear::LinearRegression as LinfaLinearRegression;
 use linfa_svm::Svm as LinfaSvm;
 
 use ndarray::{Array1, Array2, Ix1};
-use once_cell::sync::Lazy;
 use smartcore::{
     dataset::Dataset as SCDataset,
     linalg::basic::matrix::DenseMatrix,
     linear::{
         elastic_net::{ElasticNet as SCElasticNet, ElasticNetParameters},
-        linear_regression::LinearRegression as SCLinearRegression,
+        linear_regression::{LinearRegression as SCLinearRegression, LinearRegressionParameters},
     },
     svm::{
         svr::{SVRParameters, SVR as SCSVR},
         Kernels,
     },
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::LazyLock};
 
-use super::make_regression;
-use super::TestSize;
+use super::{make_regression, TestSize};
 use crate::array2_to_dense_matrix;
 
-pub fn dataset_to_regression_array(dataset: SCDataset<f32, f32>) -> (Array2<f64>, Array1<f64>) {
+/// Convert a `SmartCore` regression dataset into dense ndarray arrays.
+///
+/// # Panics
+///
+/// Panics if the dataset metadata and flattened data vector disagree on the
+/// expected shape.
+#[must_use]
+pub fn dataset_to_regression_array(dataset: &SCDataset<f32, f32>) -> (Array2<f64>, Array1<f64>) {
     (
         Array2::from_shape_vec(
             (dataset.num_samples, dataset.num_features),
-            dataset.data.iter().map(|elem| *elem as f64).collect(),
+            dataset.data.iter().map(|elem| f64::from(*elem)).collect(),
         )
-        .unwrap()
-        .to_owned(),
-        Array1::from_vec(dataset.target.iter().map(|elem| *elem as f64).collect()).to_owned(),
+        .unwrap(),
+        Array1::from_vec(dataset.target.iter().map(|elem| f64::from(*elem)).collect()),
     )
 }
 
 type RegressionData = (Array2<f64>, Array1<f64>);
 type RegressionCache = HashMap<TestSize, RegressionData>;
 
-static REGRESSION_DATA_CACHE: Lazy<RegressionCache> = Lazy::new(|| {
+static REGRESSION_DATA_CACHE: LazyLock<RegressionCache> = LazyLock::new(|| {
     HashMap::from([
-        (
-            TestSize::Small,
-            dataset_to_regression_array(make_regression(100, 10, 1.0)),
-        ),
-        (
-            TestSize::Medium,
-            dataset_to_regression_array(make_regression(1000, 50, 1.0)),
-        ),
-        (
-            TestSize::Large,
-            dataset_to_regression_array(make_regression(10000, 100, 1.0)),
-        ),
+        (TestSize::Small, build_regression_data(TestSize::Small)),
+        (TestSize::Medium, build_regression_data(TestSize::Medium)),
+        (TestSize::Large, build_regression_data(TestSize::Large)),
     ])
 });
 
-fn regression_cache(size: &TestSize) -> &'static RegressionData {
+fn build_regression_data(size: TestSize) -> RegressionData {
+    let (num_samples, num_features) = match size {
+        TestSize::Small => (100, 10),
+        TestSize::Medium => (1000, 50),
+        TestSize::Large => (10000, 100),
+    };
+
+    let dataset = make_regression(size, num_samples, num_features, 1.0);
+    dataset_to_regression_array(&dataset)
+}
+
+fn regression_cache(size: TestSize) -> &'static RegressionData {
     REGRESSION_DATA_CACHE
-        .get(size)
+        .get(&size)
         .expect("regression data cache is populated for all test sizes")
 }
 
+#[must_use]
 pub fn xy_regression(size: &TestSize) -> (Array2<f64>, Array1<f64>) {
-    let (x, y) = regression_cache(size);
+    let (x, y) = regression_cache(*size);
     (x.clone(), y.clone())
 }
 
+/// Retrieve `SmartCore`-compatible regression inputs.
+///
+/// # Panics
+///
+/// Panics if the cached ndarray cannot be converted into a dense matrix.
+#[must_use]
 pub fn get_smartcore_regression_data(size: &TestSize) -> (DenseMatrix<f64>, Vec<f64>) {
     let (x, y) = xy_regression(size);
     let dense = array2_to_dense_matrix(&x).expect("valid dense matrix conversion");
     (dense, y.to_vec())
 }
 
+#[must_use]
 pub fn get_linfa_regression_data(size: &TestSize) -> Dataset<f64, f64, Ix1> {
     let (x, y) = xy_regression(size);
     Dataset::new(x, y)
 }
 
 /// Smartcore linear regression
+///
+/// # Panics
+///
+/// Panics if `SmartCore`'s linear regression fit fails.
 /// ```
 /// use smartcore_vs_linfa::{get_smartcore_regression_data, smartcore_linear_regression, TestSize};
 /// let (x, y) = get_smartcore_regression_data(&TestSize::Small);
 /// smartcore_linear_regression(&x, &y);
 /// ```
 pub fn smartcore_linear_regression(x: &DenseMatrix<f64>, y: &Vec<f64>) {
-    SCLinearRegression::fit(x, y, Default::default()).unwrap();
+    SCLinearRegression::fit(x, y, LinearRegressionParameters::default()).unwrap();
 }
 
 /// Linfa linear regression
+///
+/// # Panics
+///
+/// Panics if Linfa's linear regression fit fails.
 /// ```
 /// use smartcore_vs_linfa::{get_linfa_regression_data, linfa_linear_regression, TestSize};
 /// linfa_linear_regression(&get_linfa_regression_data(&TestSize::Small));
@@ -97,6 +119,10 @@ pub fn linfa_linear_regression(dataset: &Dataset<f64, f64, Ix1>) {
 }
 
 /// Smartcore linear regression
+///
+/// # Panics
+///
+/// Panics if `SmartCore`'s elastic net solver fails to converge.
 /// ```
 /// use smartcore_vs_linfa::{get_smartcore_regression_data, smartcore_elasticnet_regression, TestSize};
 /// let (x, y) = get_smartcore_regression_data(&TestSize::Small);
@@ -116,6 +142,10 @@ pub fn smartcore_elasticnet_regression(x: &DenseMatrix<f64>, y: &Vec<f64>) {
 }
 
 /// Linfa linear regression
+///
+/// # Panics
+///
+/// Panics if Linfa's elastic net solver fails to converge.
 /// ```
 /// use smartcore_vs_linfa::{get_linfa_regression_data, linfa_elasticnet_regression, TestSize};
 /// linfa_elasticnet_regression(&get_linfa_regression_data(&TestSize::Small));
@@ -131,6 +161,10 @@ pub fn linfa_elasticnet_regression(dataset: &Dataset<f64, f64, Ix1>) {
 }
 
 /// svm smartcore
+///
+/// # Panics
+///
+/// Panics if `SmartCore`'s SVM regression fit fails.
 /// ```
 /// use smartcore_vs_linfa::{get_smartcore_regression_data, smartcore_svm_regression, TestSize};
 /// let (x, y) = get_smartcore_regression_data(&TestSize::Small);
@@ -142,6 +176,10 @@ pub fn smartcore_svm_regression(x: &DenseMatrix<f64>, y: &Vec<f64>) {
 }
 
 /// svm linfa
+///
+/// # Panics
+///
+/// Panics if Linfa's SVM regression fit fails.
 /// ```
 /// use smartcore_vs_linfa::{get_linfa_regression_data, linfa_svm_regression, TestSize};
 /// linfa_svm_regression(&get_linfa_regression_data(&TestSize::Small));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,12 @@
 use std::fmt::{Display, Formatter};
 
+use ndarray::Array2;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use rand_distr::{Distribution, Normal};
+
+use smartcore::{dataset::Dataset, error::Failed, linalg::basic::matrix::DenseMatrix};
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum TestSize {
     Small,
@@ -17,15 +24,72 @@ impl Display for TestSize {
     }
 }
 
-use ndarray::Array2;
-use rand::prelude::*;
-use rand_distr::Normal;
+fn scenario_seed(test_size: TestSize, scenario: &str) -> u64 {
+    match (scenario, test_size) {
+        ("regression", TestSize::Small) => 0xA11C_E511,
+        ("regression", TestSize::Medium) => 0xA11C_E522,
+        ("regression", TestSize::Large) => 0xA11C_E533,
+        ("classification", TestSize::Small) => 0xC1A5_51F1,
+        ("classification", TestSize::Medium) => 0xC1A5_5202,
+        ("classification", TestSize::Large) => 0xC1A5_5303,
+        ("clustering", TestSize::Small) => 0xC1C7_0111,
+        ("clustering", TestSize::Medium) => 0xC1C7_0222,
+        ("clustering", TestSize::Large) => 0xC1C7_0333,
+        _ => panic!(
+            "no deterministic seed registered for scenario '{scenario}' and test size '{test_size}'"
+        ),
+    }
+}
 
-use smartcore::{dataset::Dataset, error::Failed, linalg::basic::matrix::DenseMatrix};
+/// Create a reproducible random number generator for a benchmarking scenario.
+///
+/// The `scenario` parameter distinguishes between the data domains used in this
+/// crate (`"regression"`, `"classification"`, and `"clustering"`). Each
+/// combination of [`TestSize`] and scenario maps to a stable `u64` seed to
+/// ensure that generated datasets remain deterministic across runs.
+///
+/// # Panics
+///
+/// Panics if `scenario` is not one of the supported dataset domains.
+///
+/// # Examples
+/// ```
+/// use rand::RngCore;
+/// use smartcore_vs_linfa::{seeded_rng, TestSize};
+///
+/// let mut rng_a = seeded_rng(TestSize::Small, "regression");
+/// let mut rng_b = seeded_rng(TestSize::Small, "regression");
+/// assert_eq!(rng_a.next_u64(), rng_b.next_u64());
+/// ```
+#[must_use]
+pub fn seeded_rng(test_size: TestSize, scenario: &str) -> StdRng {
+    StdRng::seed_from_u64(scenario_seed(test_size, scenario))
+}
 
-pub fn make_regression(num_samples: usize, num_features: usize, noise: f32) -> Dataset<f32, f32> {
+/// Generate a deterministic linear regression dataset.
+///
+/// # Panics
+///
+/// Panics if `noise` is not strictly positive because the underlying normal
+/// distribution cannot be constructed.
+///
+/// # Examples
+/// ```
+/// use smartcore_vs_linfa::{make_regression, TestSize};
+///
+/// let dataset = make_regression(TestSize::Small, 4, 2, 0.1);
+/// assert_eq!(dataset.num_samples, 4);
+/// assert_eq!(dataset.num_features, 2);
+/// ```
+#[must_use]
+pub fn make_regression(
+    test_size: TestSize,
+    num_samples: usize,
+    num_features: usize,
+    noise: f32,
+) -> Dataset<f32, f32> {
     let noise = Normal::new(0.0, noise).unwrap();
-    let mut rng = rand::thread_rng();
+    let mut rng = seeded_rng(test_size, "regression");
 
     let mut x: Vec<f32> = Vec::with_capacity(num_samples * num_features);
     let mut y: Vec<f32> = Vec::with_capacity(num_samples);
@@ -60,4 +124,35 @@ pub fn make_regression(num_samples: usize, num_features: usize, noise: f32) -> D
 pub fn array2_to_dense_matrix(data: &Array2<f64>) -> Result<DenseMatrix<f64>, Failed> {
     let row_vectors: Vec<Vec<f64>> = data.rows().into_iter().map(|row| row.to_vec()).collect();
     DenseMatrix::from_2d_vec(&row_vectors)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::RngCore;
+
+    #[test]
+    fn regression_generation_is_deterministic() {
+        let dataset_a = make_regression(TestSize::Small, 10, 2, 0.5);
+        let dataset_b = make_regression(TestSize::Small, 10, 2, 0.5);
+
+        assert_eq!(dataset_a.data, dataset_b.data);
+        assert_eq!(dataset_a.target, dataset_b.target);
+    }
+
+    #[test]
+    fn seeded_rng_reuses_the_same_sequence() {
+        let mut rng_a = seeded_rng(TestSize::Medium, "regression");
+        let mut rng_b = seeded_rng(TestSize::Medium, "regression");
+
+        assert_eq!(rng_a.next_u64(), rng_b.next_u64());
+    }
+
+    #[test]
+    fn seeded_rng_differs_across_scenarios() {
+        let mut regression_rng = seeded_rng(TestSize::Small, "regression");
+        let mut classification_rng = seeded_rng(TestSize::Small, "classification");
+
+        assert_ne!(regression_rng.next_u64(), classification_rng.next_u64());
+    }
 }


### PR DESCRIPTION
## Summary
- add a reusable seeded RNG utility and deterministic regression generator with regression-specific tests
- rebuild the classification and clustering data caches from local seeded blob generators and document deterministic accessors
- align helpers, docs, and benchmarks with the new deterministic datasets, including updated criterion harness usage

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf23622eb48325a6bac35f75319949